### PR TITLE
made the canvas size get setted every time getCanvas is called

### DIFF
--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -179,18 +179,17 @@ export default class Webcam extends Component {
     if (!this.state.hasUserMedia) return null;
 
     const video = findDOMNode(this);
-    if (!this.ctx) {
-      let canvas = document.createElement('canvas');
-      const aspectRatio = video.videoWidth / video.videoHeight;
 
-      canvas.width = video.clientWidth;
-      canvas.height = video.clientWidth / aspectRatio;
+    if (!this.canvas) this.canvas = document.createElement('canvas');
+    const {canvas} = this;
 
-      this.canvas = canvas;
-      this.ctx = canvas.getContext('2d');
-    }
+    if (!this.ctx) this.ctx = canvas.getContext('2d');
+    const {ctx} = this;
 
-    const {ctx, canvas} = this;
+    //This is set every time incase the video element has resized
+    canvas.width = video.clientWidth;
+    canvas.height = video.videoHeight;
+
     ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
 
     return canvas;


### PR DESCRIPTION
I experienced this problem on firefox while the webcam permissions were still being requested, sometimes when `getCanvas` got called, the video element had a `height` of `0`.
The issue is, even if this height value gets corrected, the `this.canvas` will always have the old initial value.

PS. this is still not ideal, since the client can cache the canvas and never recall `getCanvas`, but at least is offers him a workaround