### PR TITLE
Improvement/set webcam resolution

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,0 +1,4 @@
+
+### Changed
+- `getUserMedia` and the video element are passed the width and height props of the component.
+- `getCanvas` returns a canvas with the same size as the video element.

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -186,11 +186,9 @@ export default class Webcam extends Component {
     if (!this.ctx) this.ctx = canvas.getContext('2d');
     const {ctx} = this;
 
-    const aspectRatio = video.videoWidth / video.videoHeight;
-
     //This is set every time incase the video element has resized
-    canvas.width = video.clientWidth;
-    canvas.height = video.clientWidth / aspectRatio;
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
 
     ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
 


### PR DESCRIPTION
1. Make the canvas take the size of video feed (instead of the size of the rendered video element)
2. Make the video feed take the size of its video element (or as close to it as possible)