### PR TITLE
Update getUserMedia API

### DIFF
--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -2,8 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { findDOMNode } from 'react-dom';
 
 function hasGetUserMedia() {
-  return !!(navigator.getUserMedia || navigator.webkitGetUserMedia ||
-            navigator.mozGetUserMedia || navigator.msGetUserMedia);
+  return !!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia)
 }
 
 export default class Webcam extends Component {
@@ -57,11 +56,6 @@ export default class Webcam extends Component {
   }
 
   requestUserMedia() {
-    navigator.getUserMedia = navigator.getUserMedia ||
-                          navigator.webkitGetUserMedia ||
-                          navigator.mozGetUserMedia ||
-                          navigator.msGetUserMedia;
-
     let sourceSelected = (audioSource, videoSource) => {
       const {width, height} = this.props;
 
@@ -90,7 +84,7 @@ export default class Webcam extends Component {
       }
 
       const getUserMediaOnSuccessBound = (constraints, onError) => {
-        navigator.getUserMedia(constraints, onSuccess , onError);
+        navigator.mediaDevices.getUserMedia(constraints).then(onSuccess).catch(onError)
       }
 
       getUserMediaOnSuccessBound(constraints, (e) => {

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -65,8 +65,8 @@ export default class Webcam extends Component {
 
   static userMediaRequested = false;
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     getUserMediaPolyfill()
     this.state = {
       hasUserMedia: false

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -1,8 +1,34 @@
 import React, { Component, PropTypes } from 'react';
 import { findDOMNode } from 'react-dom';
 
-function hasGetUserMedia() {
-  return !!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia)
+// Adapted from https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
+function getUserMediaPolyfill() {
+  // Older browsers might not implement mediaDevices at all, so we set an empty object first
+  if (navigator.mediaDevices === undefined) {
+    navigator.mediaDevices = {}
+  }
+
+  // Some browsers partially implement mediaDevices. We can't just assign an object
+  // with getUserMedia as it would overwrite existing properties.
+  // Here, we will just add the getUserMedia property if it's missing.
+  if (navigator.mediaDevices.getUserMedia === undefined) {
+    navigator.mediaDevices.getUserMedia = function(constraints) {
+
+      // First get hold of the legacy getUserMedia, if present
+      const getUserMedia = navigator.webkitGetUserMedia || navigator.mozGetUserMedia
+
+      // Some browsers just don't implement it - return a rejected promise with an error
+      // to keep a consistent interface
+      if (!getUserMedia) {
+        return Promise.reject(new Error('getUserMedia is not implemented in this browser'))
+      }
+
+      // Otherwise, wrap the call to the old navigator.getUserMedia with a Promise
+      return new Promise(function(resolve, reject) {
+        getUserMedia.call(navigator, constraints, resolve, reject)
+      })
+    }
+  }
 }
 
 export default class Webcam extends Component {
@@ -12,7 +38,7 @@ export default class Webcam extends Component {
     width: 640,
     screenshotFormat: 'image/webp',
     onUserMedia: () => {},
-    onFailure: () => {}
+    onFailure: (error) => {}
   };
 
   static propTypes = {
@@ -41,20 +67,16 @@ export default class Webcam extends Component {
 
   constructor() {
     super();
+    getUserMediaPolyfill()
     this.state = {
       hasUserMedia: false
     };
   }
 
   componentDidMount() {
-    if (!hasGetUserMedia()) {
-      this.props.onFailure()
-      return
-    }
-
     Webcam.mountedInstances.push(this);
 
-    if (!this.state.hasUserMedia && !Webcam.userMediaRequested) {
+    if (!Webcam.userMediaRequested) {
       this.requestUserMedia();
     }
   }
@@ -95,7 +117,7 @@ export default class Webcam extends Component {
         logError(e)
         if (e.name === "ConstraintNotSatisfiedError"){
           /* this is the fallback for Chrome,
-          since chrome does not accept the contrains defined as width: {exact:width}, height:{exact:height},
+          since chrome does not accept the constraints defined as width: {exact:width}, height:{exact:height},
           however firefox does not work without them.
            */
           constraints.video = {
@@ -157,7 +179,7 @@ export default class Webcam extends Component {
       this.setState({
         hasUserMedia: false
       });
-      this.props.onFailure()
+      this.props.onFailure(error)
       return;
     }
 

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -11,7 +11,8 @@ export default class Webcam extends Component {
     height: 480,
     width: 640,
     screenshotFormat: 'image/webp',
-    onUserMedia: () => {}
+    onUserMedia: () => {},
+    onFailure: () => {}
   };
 
   static propTypes = {
@@ -46,7 +47,10 @@ export default class Webcam extends Component {
   }
 
   componentDidMount() {
-    if (!hasGetUserMedia()) return;
+    if (!hasGetUserMedia()) {
+      this.props.onFailure()
+      return
+    }
 
     Webcam.mountedInstances.push(this);
 
@@ -153,7 +157,7 @@ export default class Webcam extends Component {
       this.setState({
         hasUserMedia: false
       });
-
+      this.props.onFailure()
       return;
     }
 


### PR DESCRIPTION
https://developer.mozilla.org/en/docs/Web/API/Navigator/getUserMedia

This fixes a camera bug on firefox and allows us to cope with error situations where `getUserMedia` denies access to the camera (e.g. user does not give permission)