### PR TITLE
Fixed bug on firefox for webcam unsupported resolutions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "extends": "eslint-config-airbnb",
+  "parser": "babel-eslint",
   "env": {
     "browser": true,
     "mocha": true,
@@ -8,9 +9,13 @@
   "rules": {
     "react/jsx-uses-react": 2,
     "react/jsx-uses-vars": 2,
-    "react/react-in-jsx-scope": 2
+    "react/react-in-jsx-scope": 2,
+    "no-console": 0
   },
   "plugins": [
     "react"
-  ]
+  ],
+  "ecmaFeatures": {
+    "jsx": true
+  }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,10 @@
     "react/jsx-uses-react": 2,
     "react/jsx-uses-vars": 2,
     "react/react-in-jsx-scope": 2,
-    "no-console": 0
+    "no-console": 0,
+    "comma-dangle": 0,
+    "react/sort-comp": 0,
+    "prefer-const": 0
   },
   "plugins": [
     "react"

--- a/examples/index.html
+++ b/examples/index.html
@@ -80,6 +80,7 @@
             <h1>react-webcam</h1>
             <Webcam
               ref='webcam'
+              width='960' height='640'
             />
             <div>
               <h2>CSS Filters</h2>

--- a/examples/index.html
+++ b/examples/index.html
@@ -61,7 +61,6 @@
   <script src="//fb.me/react-with-addons-0.14.7.js"></script>
   <script src="//fb.me/react-dom-0.14.7.js"></script>
   <script src="//npmcdn.com/babel-transform-in-browser@6.4.6/dist/btib.min.js"></script>
-  <script src="../dist/react-webcam.js"></script>
   <script type="text/es2015">
     // getUserMedia only works for secure pages
     if (!/https/.test(window.location.protocol)) window.location.protocol = 'https://';

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prepublish": "npm run build:umd",
     "build": "webpack",
     "build:umd": "npm run build && NODE_ENV=production webpack",
-    "lint": "eslint src",
+    "lint": "eslint src --fix",
     "dev": "webpack-dev-server --inline --hot --progress --https"
   },
   "repository": {
@@ -32,11 +32,11 @@
   "devDependencies": {
     "babel": "^5.6.7",
     "babel-core": "^5.6.18",
-    "babel-eslint": "^3.1.15",
+    "babel-eslint": "^5.0.1",
     "babel-loader": "^5.1.4",
-    "eslint": "^0.23",
-    "eslint-config-airbnb": "0.0.6",
-    "eslint-plugin-react": "^2.3.0",
+    "eslint": "^1.10.3",
+    "eslint-config-airbnb": "^2.1.0",
+    "eslint-plugin-react": "^3.13.0",
     "html-webpack-plugin": "^2.23.0",
     "webpack": "^1.9.6",
     "webpack-dev-server": "^1.16.4"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "prepublish": "npm run build:umd",
     "build": "webpack src/react-webcam.js dist/react-webcam.js",
     "build:umd": "npm run build && NODE_ENV=production webpack src/react-webcam.js dist/react-webcam.min.js",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "dev": "webpack-dev-server --inline --hot --progress --https"
   },
   "repository": {
     "type": "git",
@@ -36,6 +37,8 @@
     "eslint": "^0.23",
     "eslint-config-airbnb": "0.0.6",
     "eslint-plugin-react": "^2.3.0",
-    "webpack": "^1.9.6"
+    "html-webpack-plugin": "^2.23.0",
+    "webpack": "^1.9.6",
+    "webpack-dev-server": "^1.16.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/react-webcam.js",
   "scripts": {
     "prepublish": "npm run build:umd",
-    "build": "webpack src/react-webcam.js dist/react-webcam.js",
-    "build:umd": "npm run build && NODE_ENV=production webpack src/react-webcam.js dist/react-webcam.min.js",
+    "build": "webpack",
+    "build:umd": "npm run build && NODE_ENV=production webpack",
     "lint": "eslint src",
     "dev": "webpack-dev-server --inline --hot --progress --https"
   },

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -1,20 +1,20 @@
 import React, { Component, PropTypes } from 'react';
 import { findDOMNode } from 'react-dom';
 
-const hasGetUserMedia = !!(getUserMediaPonyfill())
+const hasGetUserMedia = !!(getUserMediaPonyfill());
 
 // Adapted from https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
 // Use a pony fill to avoid editing global objects
 function getUserMediaPonyfill() {
-  const mediaDevices = navigator.mediaDevices && navigator.mediaDevices.getUserMedia
+  const mediaDevices = navigator.mediaDevices && navigator.mediaDevices.getUserMedia;
   if (mediaDevices) {
-    return navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices)
+    return navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
   }
   /*
   Ignoring the old api, due to inconsistent behaviours
   */
   else {
-    return null
+    return null;
   }
 }
 
@@ -59,8 +59,8 @@ export default class Webcam extends Component {
     };
 
     if (!hasGetUserMedia) {
-      const error = new Error('getUserMedia is not supported by this browser')
-      this.props.onFailure(error)
+      const error = new Error('getUserMedia is not supported by this browser');
+      this.props.onFailure(error);
     }
   }
 
@@ -74,7 +74,7 @@ export default class Webcam extends Component {
 
   requestUserMedia() {
     let sourceSelected = (audioSource, videoSource) => {
-      const {width, height} = this.props;
+      const { width, height } = this.props;
       /* There is an inconsistency between Chrome v58 and Firefox
       Exact works in a different way to firefox, tf the requested exact resolution
       is higher than the supported webcam resolution then Chrome will upscale,
@@ -105,7 +105,7 @@ export default class Webcam extends Component {
       let constraints = {
         video: {
           sourceId: videoSource,
-          advanced: [{width, height}]
+          advanced: [{ width, height }]
         }
       };
 
@@ -115,19 +115,19 @@ export default class Webcam extends Component {
         };
       }
 
-      const logError = e => console.log("error", e, typeof e)
+      const logError = e => console.log('error', e, typeof e);
 
       const onSuccess = stream => {
         Webcam.mountedInstances.forEach((instance) => instance.handleUserMedia(stream));
-      }
+      };
 
       const onError = e => {
-        logError(e)
+        logError(e);
         Webcam.mountedInstances.forEach((instance) => instance.handleError(e));
-      }
+      };
 
-      const getUserMedia = getUserMediaPonyfill()
-      getUserMedia(constraints).then(onSuccess).catch(onError)
+      const getUserMedia = getUserMediaPonyfill();
+      getUserMedia(constraints).then(onSuccess).catch(onError);
     };
 
     if (this.props.audioSource && this.props.videoSource) {
@@ -172,11 +172,11 @@ export default class Webcam extends Component {
     Webcam.userMediaRequested = true;
   }
 
-  handleError (error) {
+  handleError(error) {
     this.setState({
       hasUserMedia: false
     });
-    this.props.onFailure(error)
+    this.props.onFailure(error);
   }
 
   handleUserMedia(stream) {
@@ -229,10 +229,10 @@ export default class Webcam extends Component {
     const video = findDOMNode(this);
 
     if (!this.canvas) this.canvas = document.createElement('canvas');
-    const {canvas} = this;
+    const { canvas } = this;
 
     if (!this.ctx) this.ctx = canvas.getContext('2d');
-    const {ctx} = this;
+    const { ctx } = this;
 
     //This is set every time incase the video element has resized
     canvas.width = video.videoWidth;

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -77,25 +77,22 @@ export default class Webcam extends Component {
     const sourceSelected = (audioSource, videoSource) => {
       const { width, height } = this.props;
       /* There is an inconsistency between Chrome v58 and Firefox
-      Exact works in a different way to firefox, tf the requested exact resolution
-      is higher than the supported webcam resolution then Chrome will upscale,
-      however Firefox will trigger an OverConstraintError. I suspect Firefox is
-      following the standard
+      `exact` resolution constraint works in a different way to firefox. If the requested `exact` resolution is higher than the supported webcam resolution then Chrome will upscale.
+      However Firefox will trigger an OverConstraintError. I suspect Firefox is following the standard
 
-      In case a non exact resolution is requested, instead an ideal is, Firefox
-      will handle all cases gracefully and prepare a resolution which is
-      as close as possible to the requested one.
+      In case a non exact resolution is requested, instead an `ideal` is, Firefox will handle all cases gracefully and prepare a resolution which is as close as possible to the requested one.
       If the supported webcam resolution is higher than the requested one, then it downscales;
       if it's lower, then it gives the highest available.
       However, Chrome will just give the lowest resolution of the webcam, this seems like a bug.
 
-      Therefore, if one wants the ideal constraint functionality,
-      the exact constraint works best on Chrome and the ideal one best on Firefox.
+      Therefore, if one wants the ideal constraint functionality, the `exact` constraint works best on Chrome and the ideal one best on Firefox.
 
-      This lead us to use advanced to create a list of potential fallbacks.
-      The weird thing is, that Chrome seems to work consistently with Firefox if advanced is used.
-      Which means that the fallback list is not necessary, but setting
-      the one constraint on advanced is necessary to get Chrome to act consistently.
+      This lead us to use the `advanced` constraint to create a list of potential constraint fallbacks.
+      The weird thing is, that Chrome seems to work well with `ideal` if the constraint is defined as list element in `advanced`.
+      Which means that setting a list with multiple fallbacks is not necessary, but setting the one constaint in `advance` is.
+
+      The problem is that Firefox does not work with ideal well if advanced is used,
+      which means the ideal needs to go on the parent constraint, together with advanced for Chome.
 
       ref: https://webrtchacks.com/getusermedia-resolutions-3/
       ref: https://w3c.github.io/mediacapture-main/getusermedia.html#constrainable-interface
@@ -106,7 +103,8 @@ export default class Webcam extends Component {
       const constraints = {
         video: {
           sourceId: videoSource,
-          advanced: [{ width, height }]
+          width, height,//Necessary to get Firefox to work with ideal resolutions
+          advanced: [{ width, height }]//Necessary to get Chrome to work with ideal resolutions
         }
       };
 

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -104,13 +104,27 @@ export default class Webcam extends Component {
       const getUserMedia = getUserMediaPonyfill()
       getUserMedia(constraints).then(onSuccess).catch((e) => {
         if (e.name.toLowerCase().includes("constrain") ){
-          /* this is the fallback for Firefox due to a Chrome problem,
-          since chrome does not work with ideal resolutions, only `exact` seems to work,
-          however firefox respects `exact` too much and will fail if the webcam does not have the `exact` resolution
+          /* This is a fallback for Firefox due to an inconsistency with Chrome
+          If the requested exact resolution is higher than the supported webcam resolution
+          Chrome will upscale, however Firefox will trigger an OverConstraintError.
+
+          In case a non exact resolution is requested, Firefox will handle all cases gracefully
+          and prepare a resolution which is as close as possible to the requested one.
+          If the supported webcam resolution is higher than the requested one, then it downscales;
+          if it's lower, then it gives the highest available.
+
+          However, if no exact resolution is set, then Chrome will give the lowest resolution
+          of the webcam, this seems like a bug.
+
+          Therefore, the exact constrainst works best on Chrome and the ideal one best on Firefox.
+
+          ref: https://webrtchacks.com/getusermedia-resolutions-3/
+          ref: https://w3c.github.io/mediacapture-main/getusermedia.html#constrainable-interface
+          ref: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
            */
           constraints.video = {
             sourceId: videoSource,
-            width, height
+            width, height//this is the same as using ìdeal
           }
           getUserMedia(constraints).then(onSuccess).catch(onError)
         }

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -5,7 +5,7 @@ import { findDOMNode } from 'react-dom';
 Deliberatly ignoring the old api, due to very inconsistent behaviours
 */
 const mediaDevices = navigator.mediaDevices;
-const getUserMedia = mediaDevices && mediaDevices.getUserMedia && mediaDevices.getUserMedia.bind(mediaDevices);
+const getUserMedia = mediaDevices && mediaDevices.getUserMedia ? mediaDevices.getUserMedia.bind(mediaDevices) : null;
 const hasGetUserMedia = !!(getUserMedia);
 
 export default class Webcam extends Component {

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -118,12 +118,12 @@ export default class Webcam extends Component {
       const logError = e => console.log("error", e, typeof e)
 
       const onSuccess = stream => {
-        this.handleUserMedia(stream);
+        Webcam.mountedInstances.forEach((instance) => instance.handleUserMedia(stream));
       }
 
       const onError = e => {
         logError(e)
-        this.handleError(e);
+        Webcam.mountedInstances.forEach((instance) => instance.handleError(e));
       }
 
       const getUserMedia = getUserMediaPonyfill()

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -1,8 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { findDOMNode } from 'react-dom';
 
-const hasGetUserMedia = !!(getUserMediaPonyfill());
-
 // Adapted from https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
 // Use a pony fill to avoid editing global objects
 function getUserMediaPonyfill() {
@@ -13,25 +11,17 @@ function getUserMediaPonyfill() {
   /*
   Ignoring the old api, due to inconsistent behaviours
   */
-  else {
-    return null;
-  }
+  return null;
 }
 
-export default class Webcam extends Component {
-  static defaultProps = {
-    audio: true,
-    height: 480,
-    width: 640,
-    screenshotFormat: 'image/webp',
-    onUserMedia: () => {},
-    onFailure: (error) => {}
-  };
+const hasGetUserMedia = !!(getUserMediaPonyfill());
 
+export default class Webcam extends Component {
   static propTypes = {
     audio: PropTypes.bool,
     muted: PropTypes.bool,
     onUserMedia: PropTypes.func,
+    onFailure: PropTypes.func,
     height: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.string
@@ -45,7 +35,18 @@ export default class Webcam extends Component {
       'image/png',
       'image/jpeg'
     ]),
-    className: PropTypes.string
+    className: PropTypes.string,
+    audioSource: PropTypes.string,
+    videoSource: PropTypes.string
+  };
+
+  static defaultProps = {
+    audio: true,
+    height: 480,
+    width: 640,
+    screenshotFormat: 'image/webp',
+    onUserMedia: () => {},
+    onFailure: () => {}
   };
 
   static mountedInstances = [];
@@ -73,7 +74,7 @@ export default class Webcam extends Component {
   }
 
   requestUserMedia() {
-    let sourceSelected = (audioSource, videoSource) => {
+    const sourceSelected = (audioSource, videoSource) => {
       const { width, height } = this.props;
       /* There is an inconsistency between Chrome v58 and Firefox
       Exact works in a different way to firefox, tf the requested exact resolution
@@ -102,7 +103,7 @@ export default class Webcam extends Component {
       ref: https://github.com/webrtc/adapter/issues/408 They discuss the Chrome bug
       ref: https://bugs.chromium.org/p/chromium/issues/detail?id=682887 the actual chrome bug
        */
-      let constraints = {
+      const constraints = {
         video: {
           sourceId: videoSource,
           advanced: [{ width, height }]
@@ -180,7 +181,7 @@ export default class Webcam extends Component {
   }
 
   handleUserMedia(stream) {
-    let src = window.URL.createObjectURL(stream);
+    const src = window.URL.createObjectURL(stream);
     if (this.state.src) window.URL.revokeObjectURL(src);
 
     this.stream = stream;
@@ -193,7 +194,7 @@ export default class Webcam extends Component {
   }
 
   componentWillUnmount() {
-    let index = Webcam.mountedInstances.indexOf(this);
+    const index = Webcam.mountedInstances.indexOf(this);
     Webcam.mountedInstances.splice(index, 1);
 
     if (Webcam.mountedInstances.length === 0 && this.state.hasUserMedia) {
@@ -219,7 +220,7 @@ export default class Webcam extends Component {
   getScreenshot() {
     if (!this.state.hasUserMedia) return null;
 
-    let canvas = this.getCanvas();
+    const canvas = this.getCanvas();
     return canvas.toDataURL(this.props.screenshotFormat);
   }
 
@@ -234,7 +235,7 @@ export default class Webcam extends Component {
     if (!this.ctx) this.ctx = canvas.getContext('2d');
     const { ctx } = this;
 
-    //This is set every time incase the video element has resized
+    // This is set every time incase the video element has resized
     canvas.width = video.videoWidth;
     canvas.height = video.videoHeight;
 

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - 5
+os:
+  - linux

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,8 +56,7 @@ module.exports = {
   devServer: {
     port: process.env.PORT || 3333,
     host: '0.0.0.0',
-    publicPath: '/',
-    contentBase: './dist'
+    publicPath: '/'
   },
   plugins: plugins
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,7 +51,7 @@ module.exports = {
     library: 'Webcam',
     libraryTarget: 'umd',
     path: `./dist`,
-    filename: 'react-webcam.js'
+    filename: process.env.NODE_ENV === 'production' ? 'react-webcam.min.js' : 'react-webcam.js'
   },
   devServer: {
     port: process.env.PORT || 3333,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,16 @@
 'use strict';
 
 var webpack = require('webpack');
+var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 var plugins = [
   new webpack.optimize.OccurenceOrderPlugin(),
   new webpack.DefinePlugin({
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+  }),
+  new HtmlWebpackPlugin({
+    template: './examples/index.html',
+    minify: { collapseWhitespace: true }
   })
 ];
 
@@ -21,6 +26,7 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 module.exports = {
+  entry: './src/react-webcam.js',
   externals: [{
     react: {
       root: 'React',
@@ -43,7 +49,15 @@ module.exports = {
   },
   output: {
     library: 'Webcam',
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    path: `./dist`,
+    filename: 'react-webcam.js'
+  },
+  devServer: {
+    port: process.env.PORT || 3333,
+    host: '0.0.0.0',
+    publicPath: '/',
+    contentBase: './dist'
   },
   plugins: plugins
 };


### PR DESCRIPTION
### Scope

Webcam will not work if the specified resolution is higher than the supported resolutions of the webcam (on Firefox)

### Technical considerations

There is an inconsistency between Chrome v58 and Firefox.
`exact` resolution constraint works in a different way to firefox. If the requested `exact` resolution is higher than the supported webcam resolution then Chrome will upscale.
However Firefox will trigger an OverConstraintError. I suspect Firefox is following the standard

In case a non exact resolution is requested, instead an `ideal` is, Firefox will handle all cases gracefully and prepare a resolution which is as close as possible to the requested one.
If the supported webcam resolution is higher than the requested one, then it downscales;
if it's lower, then it gives the highest available.
However, Chrome will just give the lowest resolution of the webcam, this seems like a bug.

Therefore, if one wants the ideal constraint functionality, the `exact` constraint works best on Chrome and the ideal one best on Firefox.

This lead us to use the `advanced` constraint to create a list of potential constraint fallbacks.
The weird thing is, that Chrome seems to work well with `ideal` if the constraint is defined as list element in `advanced`.
Which means that setting a list with multiple fallbacks is not necessary, but setting the one constaint in `advance` is.

The problem is that Firefox does not work with ideal well if advanced is used,
which means the ideal needs to go on the parent constraint, together with advanced for Chome.

ref: https://webrtchacks.com/getusermedia-resolutions-3/
ref: https://w3c.github.io/mediacapture-main/getusermedia.html#constrainable-interface
ref: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
ref: https://github.com/webrtc/adapter/issues/408 They discuss the Chrome bug
ref: https://bugs.chromium.org/p/chromium/issues/detail?id=682887 the actual chrome bug

#### Tooling

1. Webcam dev server and Travis building has been introduced.
2. Fixed linter and its errors
