### PR TITLE
Improvement/babel runtime as external dep

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,9 +6,9 @@
   ],
   "plugins": [
     ["transform-runtime", {
-      "helpers": false,
-      "polyfill": true,
-      "regenerator": true,
+      "helpers": true,
+      "polyfill": false,
+      "regenerator": false,
       "moduleName": "babel-runtime"
     }],
     ["transform-react-jsx"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webcam-onfido",
-  "version": "0.0.20",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1065,18 +1065,9 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "2.5.3",
         "regenerator-runtime": "0.11.1"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-          "dev": true
-        }
       }
     },
     "babel-template": {
@@ -1640,8 +1631,7 @@
     "core-js": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-      "dev": true
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -5499,8 +5489,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regenerator-transform": {
       "version": "0.10.1",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,11 @@
     "flow-bin": "^0.63.1",
     "flow-copy-source": "^1.2.1",
     "html-webpack-plugin": "^2.29.0",
+    "travis-weigh-in": "^1.0.2",
     "webpack": "^3.10.0",
-    "webpack-dev-server": "^2.9.6",
-    "travis-weigh-in": "^1.0.2"
+    "webpack-dev-server": "^2.9.6"
   },
-  "dependencies": {}
+  "dependencies": {
+    "babel-runtime": "^6.26.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/react-webcam.js",
   "scripts": {
     "prepublish": "npm run build",
-    "build": "npm run build:prod && npm run build:dev && npm run build:flow",
+    "build": "npm run build:prod && npm run build:flow",
     "build:prod": "NODE_ENV=production webpack",
     "build:dev": "webpack",
     "build:flow": "flow-copy-source -v src dist",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,16 +12,7 @@ const plugins = [
   })
 ];
 
-if (process.env.NODE_ENV === 'production') {
-  plugins.push(
-    new webpack.optimize.UglifyJsPlugin({
-      compressor: {
-        screw_ie8: true,
-        warnings: false
-      }
-    })
-  );
-}
+const isProd = process.env.NODE_ENV === 'production'
 
 module.exports = {
   entry: './src/react-webcam.js',
@@ -32,7 +23,7 @@ module.exports = {
       commonjs: 'react',
       amd: 'react'
     }
-  }, /^babel-runtime/],
+  }, isProd ? /^babel-runtime/ : ''],
   module: {
     rules: [{
       test: /\.js$/,
@@ -46,7 +37,7 @@ module.exports = {
     library: 'Webcam',
     libraryTarget: 'umd',
     path: `${__dirname}/dist`,
-    filename: process.env.NODE_ENV === 'production' ? 'react-webcam.min.js' : 'react-webcam.js'
+    filename: 'react-webcam.js'
   },
   devServer: {
     port: process.env.PORT || 3333,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = {
       commonjs: 'react',
       amd: 'react'
     }
-  }],
+  }, /^babel-runtime/],
   module: {
     rules: [{
       test: /\.js$/,


### PR DESCRIPTION
# Problem

React webcam uses babel and so can its clients. This lead to duplicate code.

# Solution

1. Use babel runtime to remove inlined babel code and instead use the runtime as a dependency that can be shared across projects.
2. Removed minification from the prod build since it's a commonjs package, the client can take care of the minification process.
3. Dev build, with babel runtime bundled in, is used now only for the webpack dev server