### PR TITLE
Add fallback constraints

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,8 @@
+## 0.1.4
+
+### Changed
+- Rejected getUserMedia calls, that don't fail due to denied permissions, will be retried one more time with fallback constraints, omitting width and height.
+
 ## 0.1.3
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webcam-onfido",
-  "version": "0.1.4-rc.1",
+  "version": "0.1.4",
   "description": "React webcam component",
   "main": "dist/react-webcam.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webcam-onfido",
-  "version": "0.1.3",
+  "version": "0.1.4-rc.1",
   "description": "React webcam component",
   "main": "dist/react-webcam.js",
   "scripts": {

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -103,7 +103,7 @@ export default class Webcam extends Component<CameraType, State> {
       Webcam.mountedInstances.forEach((instance) => instance.handleUserMedia(stream));
     };
 
-    const fallbackConstraints = {video: true, audio };
+    const fallbackConstraints = { video: true, audio, facingMode };
 
     let hasTriedFallbackConstraints;
     const onError = e => {

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -97,13 +97,20 @@ export default class Webcam extends Component<CameraType, State> {
       facingMode,
     }, audio};
 
+    const fallbackConstraints = {
+      ...constraints,
+      video: {
+        ...constraints.video,
+        width: undefined,
+        height: undefined,
+      },
+    };
+
     const logError = e => console.log('error', e, typeof e);
 
     const onSuccess = stream => {
       Webcam.mountedInstances.forEach((instance) => instance.handleUserMedia(stream));
     };
-
-    const fallbackConstraints = { video: true, audio, facingMode };
 
     let hasTriedFallbackConstraints;
     const onError = e => {

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -35,6 +35,8 @@ type State = {
   mirrored: boolean
 }
 
+const unrecoverableErrors = ['PermissionDeniedError', 'NotAllowedError', 'NotReadableError', 'NotFoundError'];
+
 export default class Webcam extends Component<CameraType, State> {
   static defaultProps = {
     audio: false,
@@ -89,7 +91,11 @@ export default class Webcam extends Component<CameraType, State> {
 
     // if `{facingMode: 'user'}` Firefox will still allow the user to choose which camera to use (Front camera will be the first option)
     // if `{facingMode: {exact: 'user'}}` Firefox won't give the user a choice and will show the front camera
-    const constraints = {video: {width, height, facingMode}, audio};
+    const constraints = {video: {
+      width: parseInt(width, 10) || width, // some devices need number types
+      height: parseInt(height, 10) || height,
+      facingMode,
+    }, audio};
 
     const logError = e => console.log('error', e, typeof e);
 
@@ -97,9 +103,18 @@ export default class Webcam extends Component<CameraType, State> {
       Webcam.mountedInstances.forEach((instance) => instance.handleUserMedia(stream));
     };
 
+    const fallbackConstraints = {video: true, audio };
+
+    let hasTriedFallbackConstraints;
     const onError = e => {
       logError(e);
-      Webcam.mountedInstances.forEach((instance) => instance.handleError(e));
+      const recoverableError = !unrecoverableErrors.includes(e.name);
+      if (!recoverableError || hasTriedFallbackConstraints) {
+        Webcam.mountedInstances.forEach((instance) => instance.handleError(e));
+      } else {
+        hasTriedFallbackConstraints = true;
+        getUserMedia(fallbackConstraints).then(onSuccess).catch(onError);
+      }
     };
     getUserMedia(constraints).then(onSuccess).catch(onError);
   }


### PR DESCRIPTION
### Problem
Certain devices, mostly Android, only accept set resolutions that match exactly the supported resolution. This causes problems because we cannot find out easily what are the supported resolutions. Additionally, some devices will also fail if `width` and `height` constraints are not `Number`s.

### Solution
The proposed solution is to try fallback constraints to see if we can get the camera stream. `optional` constraints do seem to work on some devices, but not in many others. The most promising constraints seems to be omitting `width` and `height`.

### Testing results (using BrowserStack)

Devices on which this behaviour was reproduced, and can recover from the error by omitting `width` and `height`:

```
- (Android 5) Moto G 2nd Gen Chrome // optional DOES NOT work
- (Android 5) Moto X 2nd Gen Chrome // optional DOES NOT work
- (Android 6) Moto X 2nd Gen Chrome // optional DOES NOT work
- (Android 7) Galaxy S8+ Chrome // needs Number type
- (Android 7) Nexus 6p Chrome // optional DOES work
- (Android 7.1) Galaxy Note 8 Chrome // needs Number type
- (Android 7.1) Pixel Chrome // optional DOES work 
```

Devices that don't recover, even using looser constraints:
```
- (Android 4.4) Galaxy S6 Chrome
- (Android 4.4) Galaxy S6 Firefox
- (Android 5) Nexus 6 Chrome
```

Devices on which the issue was not reproduced:

```
- (Android 4.3) Galaxy Note 3 Chrome
- (Android 4.3) Galaxy Note 3 Firefox
- (Android 4.4) Galaxy Note 4 Chrome
- (Android 4.4) Galaxy Note 4 Firefox
- (Android 4.4) Galaxy S4 Chrome
- (Android 4.4) Galaxy S4 Firefox
- (Android 4.4) Galaxy S5 Chrome
- (Android 4.4) Galaxy S5 Firefox
- (Android 4.4) Galaxy Tab 4 10.1 Chrome
- (Android 4.4) Galaxy Tab 4 10.1 Firefox
- (Android 4.4) Nexus 5 Chrome
- (Android 4.4) Nexus 5 Firefox
- (Android 4.4) Nexus 7 Chrome
- (Android 5) Moto X 2nd Gen Firefox
- (Android 5) Nexus 6 Firefox
- (Android 5.1) Nexus 9 Chrome
- (Android 5.1) Nexus 9 Firefox
- (Android 5.1) Xperia Z5
- (Android 6) Galaxy S7 Chrome
- (Android 6) Galaxy S7 Firefox
- (Android 6) LG G5 Chrome
- (Android 6) LG G5 Firefox
- (Android 6) Nexus 6 Chrome
- (Android 6) Nexus 6 Firefox
- (Android 6) Nexus 7 Chrome
- (Android 6) Nexus 7 Firefox
- (Android 7) Galaxy S8 Chrome
- (Android 7) Galaxy S8 Firefox
- (Android 7) Galaxy S8+ Firefox
- (Android 7) Nexus 6p Firefox
- (Android 7) Nexus 5x (video height is 1 px)
- (Android 7.1) Galaxy Note 8 Firefox
- (Android 7.1) Pixel Firefox
- (Android 7.1) Pixel XL Chrome
- (Android 7.1) Pixel XL Firefox
- (Android 8) Galaxy S9 Chrome
- (Android 8) Galaxy S9 Firefox
- (Android 8) Galaxy S9+ Chrome
- (Android 8) Galaxy S9+ Firefox
- (Android 8) Pixel 2 Chrome
- (Android 8) Pixel 2 Firefox
- (Android 8) Pixel Chrome
- (Android 8) Pixel Firefox
```

