### PR TITLE
Delete width and height from video constraints

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,8 @@
+## 0.1.5
+
+### Changed
+- Width and height will be deleted from the cloned video object in fallback constraints.
+
 ## 0.1.4
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webcam-onfido",
-  "version": "0.1.5-rc.1",
+  "version": "0.1.5",
   "description": "React webcam component",
   "main": "dist/react-webcam.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webcam-onfido",
-  "version": "0.1.4",
+  "version": "0.1.5-rc.1",
   "description": "React webcam component",
   "main": "dist/react-webcam.js",
   "scripts": {

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -35,7 +35,7 @@ type State = {
   mirrored: boolean
 }
 
-const unrecoverableErrors = ['PermissionDeniedError', 'NotAllowedError', 'NotReadableError', 'NotFoundError'];
+const permissionErrors = ['PermissionDeniedError', 'NotAllowedError', 'NotReadableError', 'NotFoundError'];
 
 export default class Webcam extends Component<CameraType, State> {
   static defaultProps = {
@@ -101,10 +101,12 @@ export default class Webcam extends Component<CameraType, State> {
       ...constraints,
       video: {
         ...constraints.video,
-        width: undefined,
-        height: undefined,
       },
     };
+
+    delete fallbackConstraints.video.width;
+    delete fallbackConstraints.video.height;
+
 
     const logError = e => console.log('error', e, typeof e);
 
@@ -115,8 +117,8 @@ export default class Webcam extends Component<CameraType, State> {
     let hasTriedFallbackConstraints;
     const onError = e => {
       logError(e);
-      const recoverableError = !unrecoverableErrors.includes(e.name);
-      if (!recoverableError || hasTriedFallbackConstraints) {
+      const permissionError = !permissionErrors.includes(e.name);
+      if (!permissionError || hasTriedFallbackConstraints) {
         Webcam.mountedInstances.forEach((instance) => instance.handleError(e));
       } else {
         hasTriedFallbackConstraints = true;


### PR DESCRIPTION
Related to #20.

After further testing on physical devices, some of them seem not to accept `undefined` `width` and `height` constraints.

This PR  `delete`s `width` and `height` keys entirely from the `video` constraints object.

The same devices on which rejected `getUserMedia` calls succeed with fallback constraints can still verify the same result:

```
- (Android 5) Moto G 2nd Gen Chrome
- (Android 5) Moto X 2nd Gen Chrome
- (Android 6) Moto X 2nd Gen Chrome
- (Android 7) Galaxy S8+ Chrome
- (Android 7) Nexus 6p Chrome
- (Android 7.1) Galaxy Note 8 Chrome
- (Android 7.1) Pixel Chrome
```