### PR TITLE
DO NOT MERGE Add tests for getUserMedia constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 *.log
+*.err
 .DS_Store
 dist
 lib

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webcam-onfido",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -52,6 +52,15 @@
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
+      }
+    },
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "dev": true,
+      "requires": {
+        "es6-promisify": "5.0.0"
       }
     },
     "ajv": {
@@ -1163,8 +1172,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
       "version": "1.2.1",
@@ -1238,7 +1246,6 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -1329,6 +1336,18 @@
       "dev": true,
       "requires": {
         "pako": "1.0.6"
+      }
+    },
+    "browserstack-local": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/browserstack-local/-/browserstack-local-1.3.3.tgz",
+      "integrity": "sha512-0X1bqi4NzY/7P1l3rOj5NKteH6DPgq+Mwnsj7G+t6p5lgr7R8kSBzblNyZp+HTu0YzyVZL2o/P6m+OJs0u50ng==",
+      "dev": true,
+      "requires": {
+        "https-proxy-agent": "2.2.1",
+        "is-running": "2.1.0",
+        "sinon": "1.17.7",
+        "temp-fs": "0.9.9"
       }
     },
     "buffer": {
@@ -1563,8 +1582,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.0",
@@ -1636,8 +1654,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "create-ecdh": {
       "version": "4.0.0",
@@ -2074,6 +2091,28 @@
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
+      }
+    },
+    "es6-promise": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+      "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "4.2.4"
+      },
+      "dependencies": {
+        "es6-promise": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+          "dev": true
+        }
       }
     },
     "es6-set": {
@@ -2537,6 +2576,15 @@
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
+    "formatio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+      "dev": true,
+      "requires": {
+        "samsam": "1.1.2"
+      }
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -2563,8 +2611,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.1.3",
@@ -3860,6 +3907,27 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "dev": true,
+      "requires": {
+        "agent-base": "4.2.1",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -3877,6 +3945,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
+    },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "import-local": {
       "version": "0.1.1",
@@ -3924,7 +3997,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -3933,8 +4005,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "0.12.0",
@@ -4173,6 +4244,12 @@
       "integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g==",
       "dev": true
     },
+    "is-running": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-running/-/is-running-2.1.0.tgz",
+      "integrity": "sha1-MKc/9cw4VOT8JUkICen1q/jeCeA=",
+      "dev": true
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -4200,8 +4277,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -4294,6 +4370,43 @@
       "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
       "dev": true
     },
+    "jszip": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
+      "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+      "requires": {
+        "core-js": "2.3.0",
+        "es6-promise": "3.0.2",
+        "lie": "3.1.1",
+        "pako": "1.0.6",
+        "readable-stream": "2.0.6"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+          "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU="
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
     "kefir": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/kefir/-/kefir-3.8.1.tgz",
@@ -4341,6 +4454,14 @@
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
+      }
+    },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "requires": {
+        "immediate": "3.0.6"
       }
     },
     "load-json-file": {
@@ -4409,6 +4530,12 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.0.tgz",
       "integrity": "sha1-rgyqVhERSYxboTcj1vtjHSQAOTQ=",
+      "dev": true
+    },
+    "lolex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
       "dev": true
     },
     "longest": {
@@ -4931,7 +5058,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -5018,8 +5144,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-finally": {
       "version": "1.0.0",
@@ -5060,8 +5185,7 @@
     "pako": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-      "integrity": "sha1-AQEhG6pwxLykoPY/Igbpe3368lg=",
-      "dev": true
+      "integrity": "sha1-AQEhG6pwxLykoPY/Igbpe3368lg="
     },
     "param-case": {
       "version": "2.1.1",
@@ -5121,8 +5245,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -5248,8 +5371,7 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
       "version": "1.1.8",
@@ -5665,7 +5787,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
-      "dev": true,
       "requires": {
         "glob": "7.1.2"
       },
@@ -5674,7 +5795,6 @@
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -5688,7 +5808,6 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
           "requires": {
             "brace-expansion": "1.1.8"
           }
@@ -5726,11 +5845,33 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
+    "samsam": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
       "dev": true
+    },
+    "selenium-webdriver": {
+      "version": "4.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.1.tgz",
+      "integrity": "sha512-z88rdjHAv3jmTZ7KSGUkTvo4rGzcDGMq0oXWHNIDK96Gs31JKVdu9+FMtT4KBrVoibg8dUicJDok6GnqqttO5Q==",
+      "requires": {
+        "jszip": "3.1.5",
+        "rimraf": "2.6.2",
+        "tmp": "0.0.30",
+        "xml2js": "0.4.19"
+      }
     },
     "selfsigned": {
       "version": "1.10.1",
@@ -5855,6 +5996,18 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "dev": true,
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": "0.10.3"
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -6146,6 +6299,26 @@
       "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
       "dev": true
     },
+    "temp-fs": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/temp-fs/-/temp-fs-0.9.9.tgz",
+      "integrity": "sha1-gHFzBDeHByDpQxUy/igUNk+IA9c=",
+      "dev": true,
+      "requires": {
+        "rimraf": "2.5.4"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        }
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -6177,6 +6350,14 @@
       "dev": true,
       "requires": {
         "setimmediate": "1.0.5"
+      }
+    },
+    "tmp": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.30.tgz",
+      "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
+      "requires": {
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-arraybuffer": {
@@ -6378,8 +6559,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utila": {
       "version": "0.4.0",
@@ -6985,8 +7165,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",
@@ -7002,6 +7181,20 @@
       "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
       "integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0=",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
+    "browserstack-local": "^1.3.3",
     "eslint": "^3.6.1",
     "eslint-plugin-flowtype": "^2.41.0",
     "eslint-plugin-flowtype-errors": "^3.3.6",
@@ -48,6 +49,7 @@
     "flow-bin": "^0.63.1",
     "flow-copy-source": "^1.2.1",
     "html-webpack-plugin": "^2.29.0",
+    "selenium-webdriver": "^4.0.0-alpha.1",
     "travis-weigh-in": "^1.0.2",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.9.6"

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,4 @@
+credentials.js
+*.err
+*.log
+results

--- a/test/constraints/credentials.example.js
+++ b/test/constraints/credentials.example.js
@@ -1,0 +1,4 @@
+module.exports = {
+  browserstackUser: '',
+  browserstackKey: '',
+};

--- a/test/constraints/index.html
+++ b/test/constraints/index.html
@@ -1,0 +1,167 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>React Webcam</title>
+  <style>
+    body {
+      font-family: "Helvetica Neue", Helvetica, sans-serif;
+      padding: 20px;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/preact/8.2.7/preact.js"></script>
+  <script crossorigin src="//unpkg.com/prop-types/prop-types.min.js"></script>
+  <script crossorigin src="//unpkg.com/browser-detect@0.2.28/dist/browser-detect.umd.js"></script>
+  <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/preact-compat/3.17.0/preact-compat.js"></script>
+
+  <script type="text/javascript">
+    React = preactCompat;
+    ReactDOM = preactCompat;
+  </script>
+  <script src="//npmcdn.com/babel-transform-in-browser@6.4.6/dist/btib.min.js"></script>
+  <script type="text/es2015">
+    // getUserMedia only works for secure pages
+    if (!/https/.test(window.location.protocol)) window.location.protocol = 'https://';
+    const mediaDevices = navigator.mediaDevices;
+    const getUserMedia = mediaDevices && mediaDevices.getUserMedia ? mediaDevices.getUserMedia.bind(mediaDevices) : null;
+    const hasGetUserMedia = !!(getUserMedia);
+    const noop = () => {};
+
+    const { os, name: browser, version } =  browserDetect();
+
+    class GetUserMediaTest extends React.Component{
+      constructor(props) {
+        super(props);
+        this.state = {
+          result: undefined, 
+        };
+      }
+
+      componentDidMount() {
+        const { constraints } = this.props;
+
+        getUserMedia({ audio: false, video: constraints }, noop, noop)
+          .then(this.handleSuccess.bind(this))
+          .catch(this.handleError.bind(this))
+      }
+
+      handleSuccess(stream) {
+        const { width, height } = stream.getVideoTracks()[0].getSettings();
+        stream.getVideoTracks().forEach(track => track.stop());
+        this.setState({
+          result: true,
+          trackWidth: width,
+          trackHeight: height,
+        });
+      }
+
+      handleError(e) {
+        console.log(e, this.props.constraints);
+        this.setState({
+          result: false,
+          error: e.name,
+        });
+      }
+
+      render() {
+        const { result, error, trackWidth, trackHeight } = this.state;
+        return (
+          <React.Fragment>
+            |`{ JSON.stringify(this.props.constraints).replace(/\"/g, '') }`|{
+              result === true ? `Passed|${ trackWidth }x${ trackHeight }` :
+              result === false ? `Failed|${ error }` :
+              '...Waiting'
+            }|\
+          </React.Fragment>
+        );
+      }
+    }
+    
+    const sizes = [
+      { width: 720 }, // This width fails on some devices
+      { width: 3264, height: 2448  }, // 8 MP
+      { width: 2240, height: 1680 }, // 4 MP
+      { width: 1920, height: 1080 }, // HDV
+      { width: 1280, height: 720 }, // HD 720
+      { width: 720, height: 1280 }, // Portrait
+      { width: 1000, height: 1000 }, // Square
+      { width: 640, height: 480 }, // VGA
+      { width: 320, height: 240 }, // QVGA
+      { width: 240, height: 320 }, // QVGA portrait
+    ];
+
+    class App extends React.Component {
+      state = {
+        hasPermission: undefined,
+      };
+
+      askPermission = () => {
+        getUserMedia({audio: false, video: { ...sizes[0], facingMode: 'user'}}, noop, noop)
+          .then(ev => this.handlePermissions(true, ev))
+          .catch(err => this.handlePermissions(false, err));
+      }
+
+      handlePermissions(result, err) {
+        console.log(err);
+        this.setState({
+          hasPermission: !!result,
+          error: err.name || err.message,
+        });
+      }
+
+      renderTests() {
+        return [
+          ...sizes.map(size => ({ ...size, facingMode: 'user' })),
+          // ideal
+          ...sizes.map(({ width, height }) => ({ advanced: [
+            { width: {ideal: width }},
+            { height: {ideal: height }},
+          ], facingMode: 'user'})),
+          // advanced: min/max
+          ...sizes.map(({ width, height }) => ({ advanced: [
+            { width: {min: width, max: width }},
+            { height: {min: height, max: height }},
+          ], facingMode: 'user'})),
+          // optional: min/max
+          ...sizes.map(({ width, height }) => ({optional:  [
+            { width: {min: width, max: width }},
+            { height: {min: height, max: height }},
+          ]})),
+          // optional as array
+          { optional: sizes.map(({ height }) => ({ minHeight: height })) },
+          { optional: sizes.map(({ width }) => ({ minWidth: width })) },
+          { optional: sizes.map(({ width, height }) => ({ minWidth: width, minHeight: height })) },
+          {}
+        ].map((constraints, index) =>
+          <GetUserMediaTest key={index} constraints={constraints} />
+        );
+      }
+
+      render() {
+        const { hasPermission, error } = this.state;
+        return (
+          <div id="results">
+            { os } / { browser } { version }
+            {
+              hasPermission === true ?
+                <React.Fragment>
+                  \|constraints|track size/error|\|---|---|\
+                  {this.renderTests()}
+                </React.Fragment>
+                 :
+                hasPermission === false ?
+                  <span>{error}</span> :
+                  <button id="start" onClick={this.askPermission}>Start</button>
+            }
+          </div>
+        );
+      }
+    }
+
+  ReactDOM.render(<App/>, document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/test/constraints/multiple-gum.html
+++ b/test/constraints/multiple-gum.html
@@ -1,0 +1,167 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>React Webcam</title>
+  <style>
+    body {
+      font-family: "Helvetica Neue", Helvetica, sans-serif;
+      padding: 20px;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/preact/8.2.7/preact.js"></script>
+  <script crossorigin src="//unpkg.com/prop-types/prop-types.min.js"></script>
+  <script crossorigin src="//unpkg.com/browser-detect@0.2.28/dist/browser-detect.umd.js"></script>
+  <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/preact-compat/3.17.0/preact-compat.js"></script>
+
+  <script type="text/javascript">
+    React = preactCompat;
+    ReactDOM = preactCompat;
+  </script>
+  <script src="//npmcdn.com/babel-transform-in-browser@6.4.6/dist/btib.min.js"></script>
+  <script type="text/es2015">
+    // getUserMedia only works for secure pages
+    if (!/https/.test(window.location.protocol)) window.location.protocol = 'https://';
+    const mediaDevices = navigator.mediaDevices;
+    const getUserMedia = mediaDevices && mediaDevices.getUserMedia ? mediaDevices.getUserMedia.bind(mediaDevices) : null;
+    const hasGetUserMedia = !!(getUserMedia);
+    const noop = () => {};
+
+    const { os, name: browser, version } =  browserDetect();
+
+    class GetUserMediaTest extends React.Component{
+      constructor(props) {
+        super(props);
+        this.state = {
+          result: undefined, 
+        };
+      }
+
+      componentDidMount() {
+        const { constraints } = this.props;
+
+        getUserMedia({ audio: false, video: constraints }, noop, noop)
+          .then(this.handleSuccess.bind(this))
+          .catch(this.handleError.bind(this))
+      }
+
+      handleSuccess(stream) {
+        const { width, height } = stream.getVideoTracks()[0].getSettings();
+        stream.getVideoTracks().forEach(track => track.stop());
+        this.setState({
+          result: true,
+          trackWidth: width,
+          trackHeight: height,
+        });
+      }
+
+      handleError(e) {
+        console.log(e, this.props.constraints);
+        this.setState({
+          result: false,
+          error: e.name,
+        });
+      }
+
+      render() {
+        const { result, error, trackWidth, trackHeight } = this.state;
+        return (
+          <React.Fragment>
+            |`{ JSON.stringify(this.props.constraints).replace(/\"/g, '') }`|{
+              result === true ? `Passed|${ trackWidth }x${ trackHeight }` :
+              result === false ? `Failed|${ error }` :
+              '...Waiting'
+            }|\
+          </React.Fragment>
+        );
+      }
+    }
+    
+    const sizes = [
+      { width: 720 }, // This width fails on some devices
+      { width: 3264, height: 2448  }, // 8 MP
+      { width: 2240, height: 1680 }, // 4 MP
+      { width: 1920, height: 1080 }, // HDV
+      { width: 1280, height: 720 }, // HD 720
+      { width: 720, height: 1280 }, // Portrait
+      { width: 1000, height: 1000 }, // Square
+      { width: 640, height: 480 }, // VGA
+      { width: 320, height: 240 }, // QVGA
+      { width: 240, height: 320 }, // QVGA portrait
+    ];
+
+    class App extends React.Component {
+      state = {
+        hasPermission: undefined,
+      };
+
+      askPermission = () => {
+        getUserMedia({audio: false, video: { ...sizes[0], facingMode: 'user'}}, noop, noop)
+          .then(ev => this.handlePermissions(true, ev))
+          .catch(err => this.handlePermissions(false, err));
+      }
+
+      handlePermissions(result, err) {
+        console.log(err);
+        this.setState({
+          hasPermission: !!result,
+          error: err.name || err.message,
+        });
+      }
+
+      renderTests() {
+        return [
+          ...sizes.map(size => ({ ...size, facingMode: 'user' })),
+          // ideal
+          ...sizes.map(({ width, height }) => ({ advanced: [
+            { width: {ideal: width }},
+            { height: {ideal: height }},
+          ], facingMode: 'user'})),
+          // advanced: min/max
+          ...sizes.map(({ width, height }) => ({ advanced: [
+            { width: {min: width, max: width }},
+            { height: {min: height, max: height }},
+          ], facingMode: 'user'})),
+          // optional: min/max
+          ...sizes.map(({ width, height }) => ({optional:  [
+            { width: {min: width, max: width }},
+            { height: {min: height, max: height }},
+          ]})),
+          // optional as array
+          { optional: sizes.map(({ height }) => ({ minHeight: height })) },
+          { optional: sizes.map(({ width }) => ({ minWidth: width })) },
+          { optional: sizes.map(({ width, height }) => ({ minWidth: width, minHeight: height })) },
+          {}
+        ].map((constraints, index) =>
+          <GetUserMediaTest key={index} constraints={constraints} />
+        );
+      }
+
+      render() {
+        const { hasPermission, error } = this.state;
+        return (
+          <div id="results">
+            { os } / { browser } { version }
+            {
+              hasPermission === true ?
+                <React.Fragment>
+                  \|constraints|track size/error|\|---|---|\
+                  {this.renderTests()}
+                </React.Fragment>
+                 :
+                hasPermission === false ?
+                  <span>{error}</span> :
+                  <button id="start" onClick={this.askPermission}>Start</button>
+            }
+          </div>
+        );
+      }
+    }
+
+  ReactDOM.render(<App/>, document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/test/constraints/selenium-browserstack.js
+++ b/test/constraints/selenium-browserstack.js
@@ -1,0 +1,69 @@
+const webdriver = require('selenium-webdriver');
+const { Builder, By, Key, until } = webdriver;
+const { browserstackUser, browserstackKey } = require('./credentials');
+const browserstack = require('browserstack-local');
+
+const capabilities = {
+  'acceptSslCerts': true,
+  'browserName': 'chrome',
+  'realMobile': 'true',
+  'browserstack.video' : 'false',
+  'browserstack.debug': true,
+  'browserstack.user': browserstackUser,
+  'browserstack.key': browserstackKey,
+  'browserstack.local': true,
+  'chromeOptions': {
+    'args': [
+      '--use-fake-ui-for-media-stream',
+      '--use-fake-device-for-media-stream',
+    ],
+  },
+};
+
+async function test(device) {
+  console.log('---');
+  console.log(device);
+  let driver;
+  try {
+    const BS = new browserstack.Local();
+    await new Promise(resolve => BS.start({ key: browserstackKey }, resolve));
+    driver = new Builder().
+      usingServer('http://hub-cloud.browserstack.com/wd/hub').
+      withCapabilities({...capabilities, device }).
+      build();
+
+    await driver.get('https://0.0.0.0:3333/test/constraints');
+    await driver.findElement(By.id('start')).click();
+    await driver.wait(until.elementLocated(By.id('results')), 10000);
+    const results = await driver.findElement(By.id('results')).then(element => element.getText());
+    console.log(results);
+    driver.quit();
+  } catch (e) {
+    console.log('Error.');
+    console.log(e);
+    driver.quit();
+  }
+  return true;
+}
+
+const devices = [
+  'Google Pixel 2',
+  'Google Pixel',
+  'Google Nexus 6',
+  'Google Nexus 9',
+  'Samsung Galaxy S6',
+  'Samsung Galaxy S7',
+  'Samsung Galaxy Note 4',
+  'Samsung Galaxy S8',
+  'Samsung Galaxy S8 Plus',
+  'Samsung Galaxy S9',
+  'Samsung Galaxy S9 Plus',
+  'Samsung Galaxy Note 8',
+  'Samsung Galaxy Tab 4',
+];
+
+async function main() {
+  devices.reduce((prev, device) => prev.then(() => test(device)), Promise.resolve())
+}
+
+main()

--- a/test/constraints/single-gum-recursive.html
+++ b/test/constraints/single-gum-recursive.html
@@ -1,0 +1,178 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>React Webcam</title>
+  <style>
+    body {
+      font-family: "Helvetica Neue", Helvetica, sans-serif;
+      padding: 20px;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/preact/8.2.7/preact.js"></script>
+  <script crossorigin src="//unpkg.com/prop-types/prop-types.min.js"></script>
+  <script crossorigin src="//unpkg.com/browser-detect@0.2.28/dist/browser-detect.umd.js"></script>
+  <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/preact-compat/3.17.0/preact-compat.js"></script>
+
+  <script type="text/javascript">
+    React = preactCompat;
+    ReactDOM = preactCompat;
+  </script>
+  <script src="//npmcdn.com/babel-transform-in-browser@6.4.6/dist/btib.min.js"></script>
+  <script type="text/es2015">
+    // getUserMedia only works for secure pages
+    if (!/https/.test(window.location.protocol)) window.location.protocol = 'https://';
+    const mediaDevices = navigator.mediaDevices;
+    const getUserMedia = mediaDevices && mediaDevices.getUserMedia ? mediaDevices.getUserMedia.bind(mediaDevices) : null;
+    const hasGetUserMedia = !!(getUserMedia);
+    const noop = () => {};
+
+    const { os, name: browser, version } =  browserDetect();
+
+    const RESULTS_KEY = 'gumresults';
+    const STORE_RESULTS_PARAM = 'storeResult';
+
+    const sizes = [
+      { width: 960 }, // Some devices fail with a range between 960 - 640
+      { width: 720 }, // If the above fails, this should fail too
+      { width: 961 }, // If the two above fail, this wont fail
+      { height: 480 }, // This is a potentially desired a fallback height
+      { width: 3264, height: 2448  }, // 8 MP
+      { width: 2240, height: 1680 }, // 4 MP
+      { width: 1920, height: 1080 }, // HDV
+      { width: 1280, height: 720 }, // HD 720
+      { width: 720, height: 1280 }, // Portrait
+      { width: 1000, height: 1000 }, // Square
+      { width: 640, height: 480 }, // VGA
+      { width: 320, height: 240 }, // QVGA
+      { width: 240, height: 320 }, // QVGA portrait
+    ];
+
+    const allConstraints = [
+      ...sizes.map(size => ({ ...size, facingMode: 'user' })),
+      // ideal
+      ...sizes.map(({ width, height }) => ({ advanced: [
+        { width: {ideal: width }},
+        { height: {ideal: height }},
+      ], facingMode: 'user'})),
+      // advanced: min/max
+      ...sizes.map(({ width, height }) => ({ advanced: [
+        { width: {min: width, max: width }},
+        { height: {min: height, max: height }},
+      ], facingMode: 'user'})),
+      // optional: min/max
+      ...sizes.map(({ width, height }) => ({optional:  [
+        { width: {min: width, max: width }},
+        { height: {min: height, max: height }},
+      ]})),
+      // optional as array
+      { optional: sizes.map(({ height }) => ({ minHeight: height })) },
+      { optional: sizes.map(({ width }) => ({ minWidth: width })) },
+      { optional: sizes.map(({ width, height }) => ({ minWidth: width, minHeight: height })) },
+      {}
+    ];
+
+    const GetUserMediaResult = ({ result }) => {
+      const { constraints, success, errorName, errorMessage, trackWidth, trackHeight } = result;
+      return (
+        <div>
+          |`{ JSON.stringify(constraints).replace(/\"/g, '') }`|{
+            success === true ? `Success|${ trackWidth }x${ trackHeight }` :
+            success === false ? `Failure|${ errorName }/${ errorMessage }` :
+            '...Waiting'
+          }|
+        </div>
+      );
+    };
+
+    class App extends React.Component {
+
+      constructor(props) {
+        super(props);
+        this.state = {
+          results: [],
+          done: false,
+        };
+      }
+
+      componentDidMount() {
+        if (!(new URL(window.location)).searchParams.get(STORE_RESULTS_PARAM)) {
+          window.sessionStorage.removeItem(RESULTS_KEY);
+        }
+
+        this.setState({
+          results: JSON.parse(window.sessionStorage.getItem(RESULTS_KEY) || '[]'),
+        }, () => this.callGUMWithConstraints())
+      }
+
+      callGUMWithConstraints() {
+        const { results } = this.state;
+        const constraints = allConstraints[results.length];
+        Promise.race([
+          getUserMedia({ audio: false, video: constraints }, noop, noop)
+            .then(this.handleSuccess.bind(this)),
+          new Promise((result, reject) => setTimeout(() => reject(new Error('Timeout')), 10000)),
+        ]).catch(this.handleError.bind(this))
+          .then(result => this.storeResultAndContinue({ ...result, constraints }));
+      }
+
+      handleSuccess(stream) {
+        const { width, height } = stream.getVideoTracks()[0].getSettings();
+        stream.getVideoTracks().forEach(track => track.stop());
+        return {
+          success: true,
+          trackWidth: width,
+          trackHeight: height,
+        };
+      }
+
+      handleError(e) {
+        return {
+          success: false,
+          errorName: e.name,
+          errorMessage: e.message,
+        };
+      }
+
+      storeResultAndContinue(result) {
+        const { results } = this.state;
+        const newResults = [...results, result];
+        window.sessionStorage.setItem(RESULTS_KEY, JSON.stringify(newResults));
+        if (results.length + 1 < allConstraints.length) {
+          this.reload();          
+        } else {
+          this.setState({
+            done: true,
+            results: newResults,
+          });
+        }
+      }
+
+      reload() {
+        const url = new URL(window.location);
+        url.searchParams.set(STORE_RESULTS_PARAM, true);
+        window.location.href = url.toString();
+      }
+
+      render() {
+        const { results } = this.state;
+        return (
+          <div id="results">
+            { os } / { browser } { version }
+            |constraints|track size/error||
+            |---|---|---|
+            {
+              results.map((result, index) => <GetUserMediaResult key={index} result={result} />)
+            }
+          </div>
+        );
+      }
+    }
+
+  ReactDOM.render(<App/>, document.getElementById('root'));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This is the setup used for GUM constraints tests. I'm opening this PR mostly for future reference, and maybe in case this can help at least partially automating device testing.

On one hand, on `/tests/constraints/index.html` it will prompt for permission and then call `getUserMedia` with array of constraints. Results are then output in markdown-ish format (on a single line) to allow copying from Browserstack Live (multiple lines or nested block elements did not allow so).

On the other hand I tried automating these tests using Selenium and Browserstack Automate, but results are not promising, since for getting access to the camera with Chrome `--use-fake-ui-for-media-stream` and `--use-fake-device-for-media-stream` flags need to be set, and results are exactly the same for all devices. Using `--use-fake-ui-for-media-stream` does not work, perhaps because the browser cannot access the real device camera.

Results can be seen here
https://docs.google.com/spreadsheets/d/1V_0Q-ZMGUZ4P2J8N-6aQEqflLbpfNwquv1Do9kxn8UQ/edit?usp=sharing

