### PR TITLE
Fix/facing mode typing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,7 @@
 {
   "parser": "babel-eslint",
   "extends": [
-    "eslint:recommended",
-    "plugin:flowtype/recommended"
+    "eslint:recommended"
   ],
   "env": {
     "browser": true,
@@ -17,9 +16,7 @@
     }
   },
   "plugins": [
-    "react",
-    "flowtype",
-    "flowtype-errors"
+    "react"
   ],
   "globals": {},
   "rules": {
@@ -61,7 +58,6 @@
     "no-var": 2,
     "object-shorthand": 2,
     "prefer-arrow-callback": 2,
-    "react/jsx-uses-vars": 1,
-    "flowtype-errors/show-errors": 2
+    "react/jsx-uses-vars": 1
   }
 }

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,8 @@
+## 0.1.7
+### Changed
+- Made `facingMode` a complex type rather than just `String`
+- Internal: Flow check has been moved out of the linter
+
 ## 0.1.6
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webcam-onfido",
-  "version": "0.1.3",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2498,9 +2498,9 @@
       }
     },
     "flow-bin": {
-      "version": "0.63.1",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.63.1.tgz",
-      "integrity": "sha1-qwAGfBlxaaX7W0mWyPaSewZpSCg=",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.76.0.tgz",
+      "integrity": "sha512-ywyEEEDYuItrkpx9HqRhuY78rXYbaWiNZSWgaI0KUGGeOldaTEbCZXosspxTEKqmQTCBW1/02Z2K0kC9C6hqzQ==",
       "dev": true
     },
     "flow-copy-source": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "build:prod": "NODE_ENV=production webpack",
     "build:dev": "webpack",
     "build:flow": "flow-copy-source -v src dist",
-    "prebuild": "npm run lint",
+    "prebuild": "npm run lint && npm run flow",
     "lint": "eslint src",
+    "flow": "flow check",
     "dev": "webpack-dev-server --inline --hot --progress --https"
   },
   "repository": {
@@ -42,10 +43,8 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "eslint": "^3.6.1",
-    "eslint-plugin-flowtype": "^2.41.0",
-    "eslint-plugin-flowtype-errors": "^3.3.6",
     "eslint-plugin-react": "^6.3.0",
-    "flow-bin": "^0.63.1",
+    "flow-bin": "^0.76.0",
     "flow-copy-source": "^1.2.1",
     "html-webpack-plugin": "^2.29.0",
     "travis-weigh-in": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webcam-onfido",
-  "version": "0.1.7-rc1",
+  "version": "0.1.7",
   "description": "React webcam component",
   "main": "dist/react-webcam.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webcam-onfido",
-  "version": "0.1.6",
+  "version": "0.1.7-rc1",
   "description": "React webcam component",
   "main": "dist/react-webcam.js",
   "scripts": {

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -15,6 +15,8 @@ const debugConsole = (...args) => {
 };
 
 type constraintTypes = number | Object;
+type facingModeLiterals = 'user' | 'environment'
+type facingModeType = facingModeLiterals | { exact: facingModeLiterals}
 
 type CameraType = {
   audio?: boolean,
@@ -24,7 +26,7 @@ type CameraType = {
   width?: constraintTypes,
   fallbackHeight?: constraintTypes,
   fallbackWidth?: constraintTypes,
-  facingMode?: String,
+  facingMode?: facingModeType,
   screenshotFormat?: 'image/webp' |
     'image/png' |
     'image/jpeg'
@@ -75,7 +77,7 @@ export default class Webcam extends Component<CameraType, State> {
     this.requestUserMedia();
   }
 
-  getConstraints(width: *, height: *, facingMode?: String, audio?: boolean): Object {
+  getConstraints(width: *, height: *, facingMode?: facingModeType, audio?: boolean): Object {
     /*
     Safari 11 has a bug where if you specify both the height and width
     constraints you must chose a resolution supported by the web cam. If an

--- a/src/video.js
+++ b/src/video.js
@@ -1,3 +1,5 @@
+const MediaRecorder = window.MediaRecorder;
+
 const handleDataAvailable = (event, recordedBlobs) => {
   if (event.data && event.data.size > 0) {
     recordedBlobs.push(event.data);


### PR DESCRIPTION
# Problem

Flow complained if one passed "user" to `facingMode` even though it was defined as `String`.
The error flow gave was `because string [1] is incompatible with String [2] in property`
Consumer PR: https://github.com/onfido/onfido-sdk-ui/pull/377

# Solution
Turn the type of `facingMode` into string literals.
Bonus: one can also define it as `exact` with an object sintax which matches the official standard.