### PR TITLE
Allow react-webcam to receive custom style

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+## 0.1.9
+### Added
+- Public: Added `style` prop style the video element inline
+
 ## 0.1.8
 ### Changed
 - Public: Changed `getVideoBlob()` to return a Blob with `type`

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ className        | string   | ''           | CSS class of video element
 audio            | boolean  | false        | enable/disable audio
 height           | number   | 480          | height of video element
 width            | number   | 640          | width of video element
+style            | object   | undefined    | CSS inline style
 facingMode       | string   | ''           | Facing mode of the camera. It can be `user` or `environment`
 screenshotFormat | string   | 'image/webp' | format of screenshot
 onUserMedia      | function | noop         | callback when component receives a media stream

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webcam-onfido",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "React webcam component",
   "main": "dist/react-webcam.js",
   "scripts": {

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -31,7 +31,8 @@ type CameraType = {
     'image/png' |
     'image/jpeg'
   ,
-  className?: String
+  className?: String,
+  style: Object
 }
 
 type State = {
@@ -220,7 +221,8 @@ export default class Webcam extends Component<CameraType, State> {
         style={{
           // not necessary to add prefixes, since all browsers that support camera
           // support transform
-          transform: this.state.mirrored ? 'scaleX(-1)' : ''
+          transform: this.state.mirrored ? 'scaleX(-1)' : '',
+          ...this.props.style
         }}
         ref={(el) => this.video = el}
         autoPlay


### PR DESCRIPTION
Allow react-webcam to receive custom style in order to easily fix UI issues.