### PR TITLE
Fix iOS Safari

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+## 0.1.11
+### Added
+- Public: Added 1s delay before releasing the webcam stream in order to mitigate the iOS issue where multiple re-mounting of the webcam component was causing a crash.
+
 ## 0.1.10
 ### Removed
 - Public: Removed possibility to override the style of the video element by passing inline style as a prop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webcam-onfido",
-  "version": "0.1.11-rc1",
+  "version": "0.1.11",
   "description": "React webcam component",
   "main": "dist/react-webcam.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webcam-onfido",
-  "version": "0.1.10",
+  "version": "0.1.11-rc1",
   "description": "React webcam component",
   "main": "dist/react-webcam.js",
   "scripts": {

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -243,7 +243,7 @@ export default class Webcam extends Component<CameraType, State> {
   render() {
     // React will try and optimise this on re-mounts, so make sure to explicitly
     // not render with a stream that no longer exists
-    // This is likely related to https://github.com/onfido/onfido-sdk-ui/blob/master/src/components/Confirm/index.js#L37
+    // This is likely related to https://github.com/onfido/onfido-sdk-ui/blob/249f54264f3a1674a2702b95967bb91ec6e3b90d/src/components/Confirm/index.js#L37
     // as the `video` element should not _should_ not show anything if the stream
     // is `null` anyway
     if (!this.stream) return null;

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -220,6 +220,10 @@ export default class Webcam extends Component<CameraType, State> {
   }
 
   render() {
+    // React will try and optimise this on re-mounts, so make sure to explicitly
+    // not render with a stream that no longer exists
+    if (!this.stream) return null;
+
     return (
       <video
         style={{

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -51,6 +51,8 @@ export default class Webcam extends Component<CameraType, State> {
 
   static mountedInstances = [];
 
+  static userMediaRequested = false;
+
   state = {
     hasUserMedia: false,
     mirrored: false
@@ -107,7 +109,7 @@ export default class Webcam extends Component<CameraType, State> {
   }
 
   requestUserMedia() {
-    if (!getUserMedia || !mediaDevices) return;
+    if (!getUserMedia || !mediaDevices || Webcam.userMediaRequested) return;
     const { width, height, facingMode, audio, fallbackWidth, fallbackHeight } = this.props;
 
     const constraints = this.getConstraints(width, height, facingMode, audio);
@@ -116,11 +118,13 @@ export default class Webcam extends Component<CameraType, State> {
     const logError = e => console.log('error', e, typeof e);
 
     const onSuccess = stream => {
+      Webcam.userMediaRequested = false;
       Webcam.mountedInstances.forEach((instance) => instance.handleUserMedia(stream));
     };
 
     let hasTriedFallbackConstraints;
     const onError = e => {
+      Webcam.userMediaRequested = false;
       logError(e);
       const isPermissionError = permissionErrors.includes(e.name);
       if (isPermissionError || hasTriedFallbackConstraints) {
@@ -130,6 +134,7 @@ export default class Webcam extends Component<CameraType, State> {
         getUserMedia(fallbackConstraints).then(onSuccess).catch(onError);
       }
     };
+    Webcam.userMediaRequested = true;
     getUserMedia(constraints).then(onSuccess).catch(onError);
   }
 

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -41,6 +41,19 @@ type State = {
 
 const permissionErrors = ['PermissionDeniedError', 'NotAllowedError','NotFoundError'];
 
+const stopStreamTracks = (stream: MediaStream) => {
+  if (stream.getVideoTracks) {
+    for (let track of stream.getVideoTracks()) {
+      track.stop();
+    }
+  }
+  if (stream.getAudioTracks) {
+    for (let track of stream.getAudioTracks()) {
+      track.stop();
+    }
+  }
+};
+
 export default class Webcam extends Component<CameraType, State> {
   static defaultProps = {
     audio: false,
@@ -164,18 +177,26 @@ export default class Webcam extends Component<CameraType, State> {
     const index = Webcam.mountedInstances.indexOf(this);
     Webcam.mountedInstances.splice(index, 1);
 
-    if (Webcam.mountedInstances.length === 0 && this.state.hasUserMedia) {
-      if (this.stream.getVideoTracks) {
-        for (let track of this.stream.getVideoTracks()) {
-          track.stop();
-        }
-      }
-      if (this.stream.getAudioTracks) {
-        for (let track of this.stream.getAudioTracks()) {
-          track.stop();
-        }
-      }
-    }
+    /*
+    We need to call `stopStreamTracks` since otherwise devices will continue
+    holding onto the stream (e.g. recording through the webcam, even though we
+    no longer need the stream)
+    However - some devices (namely iOS Safari) have issues with calling
+    `getUserMedia` multiple times from cold (i.e. without any existing streams
+    already running in the background), so we don't stop the stream for
+    `stopDelay` milliseconds, in an attempt to re-use the same stream, if a new
+    component is mounted soon after.
+    This issue of iOS Safari was pinpointed by unmounting and remounting the
+    webcam component multiple times, and confirming that the error occurred in
+    the `getUserMedia` request - and then testing that the error did _not_ occur
+    if we never called `.stop()` on the tracks (however we do need to relinquish
+    the stream eventually)
+    The precise value for `stopDelay` is a finger-in-the-air value, that is
+    a nice balance between the stream being relinquished (so the webcam light
+    turns off etc.), and the crash not occuring (because of the wait)
+    */
+    const stopDelay = 1000;
+    setTimeout(() => stopStreamTracks(this.stream), stopDelay);
   }
 
   getScreenshot() {
@@ -222,6 +243,9 @@ export default class Webcam extends Component<CameraType, State> {
   render() {
     // React will try and optimise this on re-mounts, so make sure to explicitly
     // not render with a stream that no longer exists
+    // This is likely related to https://github.com/onfido/onfido-sdk-ui/blob/master/src/components/Confirm/index.js#L37
+    // as the `video` element should not _should_ not show anything if the stream
+    // is `null` anyway
     if (!this.stream) return null;
 
     return (


### PR DESCRIPTION
# Problem
Currently iOS Safari will occasionally crash when coming in/out of the Selfie flow. This is most noticeable when going in/out repeatedly, but can happen in the immediate re-enter.

It appears that this is a very native-specific issue to do with the `getUserMedia` call, which actually crashes randomly (and is entirely outside of our control).

# Solution
I tried messing about with what we pass `getUserMedia`, or if any sort of back-off on calling it, or any rhyme or reason to the iOS crash it causes... But to no avail.

Frustratingly, I also can't see the wider internet complain about this issue at all, but confirmed through several tests that it was the cause of the crash. (Putting timeouts before and after the call to `getUserMedia` shows that the crash occurs specifically when _it_ is called, not in the lead up to it, or in any of the callbacks after it)

However, I also found that if we don't `.stop()` the stream tracks, then the error doesn't occur at all! We do, unfortunately, still need to call `.stop()`, since otherwise the device holds onto the webcam stream forever (and you'll have the little "webcam is recording" light on forever).

But after some trial and error, I've found that merely waiting 1 second before releasing the webcam stream is enough to _massively_ mitigate the error. This way, we still release the webcam stream, but if we allow the device to re-use the previous stream if re-mounting in less than a second.

If re-mounting in _more_ than a second, then _it seems_ that the issue is very unlikely to occur (I guess the native issue is specifically around a cold call to `getUserMedia` very soon after the resource was just released).

However, it is worth noting, this PR does not _solve_ the issue (I'm not sure we can, it's a native iOS Safari bug, that we're guessing at), but it _mitigates_ it largely. I'm not longer able to reproduce the error, after using this code.