### PR TITLE
ET-9 workaround for chrome on surface not respecting facingMode constraint

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+## 0.1.14
+### Added
+- Added alternative constraint workaround to evoke the rear camera on Surface Pro since it will not respect facingMode constraint
+
 ## 0.1.13
 ### Added
 - Check for stream first before trying for `getVideoTracks` or `getAudioTracks`

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,8 +1,8 @@
-## 0.1.14
-
+## 0.1.15
 ### Added
-- Added alternative constraint workaround to evoke the rear camera on Surface Pro since it will not respect facingMode constraint
+- Added alternative constraint workaround to evoke the rear camera of Surface Pro in Chrome since it will not respect facingMode constraint
 
+## 0.1.14
 ### Fixed
 - Added WebM container for VP8 video to include Opus audio so that MediaRecorder works for Firefox >= 71
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3413,6 +3413,11 @@
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
       "dev": true
     },
+    "enumerate-devices": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/enumerate-devices/-/enumerate-devices-1.1.1.tgz",
+      "integrity": "sha512-8zDbrc7ocusTL1ZGmvgy0cTwdyCaM7sGZoYLRmnWJalLQzmftDtce+uDU91gafOTo9MCtgjSIxyMv/F4+Hcchw=="
+    },
     "errno": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "webpack-dev-server": "^2.9.6"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.4.3"
+    "@babel/runtime-corejs3": "^7.4.3",
+    "enumerate-devices": "^1.1.1"
   }
 }

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -16,10 +16,10 @@ This function will filter devices to find the deviceId of the rear camera and us
 */
 const environmentCamConstraint = (constraints) => {
   if (constraints && typeof constraints.video === 'object') {
-    let face = constraints.video.facingMode;
-    face = face && ((typeof face === 'object') ? face : {ideal: face});
+    let facingMode = constraints.video.facingMode;
+    facingMode = facingMode && ((typeof facingMode === 'object') ? facingMode : {ideal: facingMode});
     let matches = [];
-    if (face.exact === 'environment' || face.ideal === 'environment') {
+    if (facingMode.exact === 'environment' || facingMode.ideal === 'environment') {
       matches = ['back', 'rear'];
     }
     if (matches) {
@@ -28,7 +28,7 @@ const environmentCamConstraint = (constraints) => {
         let device = devices.find(d => matches.some(match =>
           d.label.toLocaleLowerCase().includes(match)));
         if (device) {
-          constraints.video.deviceId = face.exact ? {exact: device.deviceId} : {ideal: device.deviceId};
+          constraints.video.deviceId = facingMode.exact ? {exact: device.deviceId} : {ideal: device.deviceId};
           delete constraints.video.facingMode;
         }
         return constraints;

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -10,12 +10,6 @@ const mediaDevices = navigator.mediaDevices;
 const getUserMedia = mediaDevices && mediaDevices.getUserMedia ? mediaDevices.getUserMedia.bind(mediaDevices) : null;
 const hasGetUserMedia = !!(getUserMedia);
 
-// These detections are necessary to determine when to apply the workaround on Chrome for Surface.
-const isChrome = navigator.vendor === 'Google Inc.';
-// To detect an environment or rear facing camera, the constraint can be passed in as {facingMode: "environment"} or {facingMode: {exact: "environment"}};
-// this will account for either situation. "facingMode &&" is necessary before checking facingMode.exact to avoid an error if facingMode is undefined
-const isHybrid = navigator.platform === 'Win32' && (facingMode === "environment" || (facingMode && facingMode.exact === "environment" ));
-
 /*
 Chrome on Surface Pro will not respect the facingMode constraint.
 This function will filter devices to find the deviceId of the rear camera and use that as a constraint instead.
@@ -158,6 +152,12 @@ export default class Webcam extends Component<CameraType, State> {
   async requestUserMedia() {
     if (!getUserMedia || !mediaDevices || Webcam.userMediaRequested) return;
     const { width, height, facingMode, audio, fallbackWidth, fallbackHeight } = this.props;
+
+    // These detections are necessary to determine when to apply the workaround on Chrome for Surface.
+    const isChrome = navigator.vendor === 'Google Inc.';
+    // To detect an environment or rear facing camera, the constraint can be passed in as {facingMode: "environment"} or {facingMode: {exact: "environment"}};
+    // this will account for either situation. "facingMode && facingMode.exact &&" is necessary before checking facingMode.exact to avoid an error if facingMode is undefined or doesn't contain the exact key
+    const isHybrid = navigator.platform === 'Win32' && (facingMode === "environment" || (facingMode && facingMode.exact && facingMode.exact === "environment" ));
 
     const constraints = this.getConstraints(width, height, facingMode, audio);
     const fallbackConstraints = this.getConstraints(fallbackWidth, fallbackHeight, facingMode, audio);


### PR DESCRIPTION
# Problem
Surface Pro tablet on Chrome does not respect facingMode constraint and always evokes the front camera

# Solution
Detect if the user is on Windows and Chrome, and if the constraint for facingMode has been passed in as "environment" or {exact: "environment"}. If so, enumerate devices and filter for video, search label for words "rear" or "back" and retrieve the device id, then use that as a constraint instead.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
