### PR TITLE
Bug/CX-4645 video recording not supported in Firefox >= 71 

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+## 0.1.14
+### Fixed
+- Update WebM container for VP8 video to include Opus audio so that MediaRecorder works for Firefox >= 71
+
 ## 0.1.13
 ### Added
 - Check for stream first before trying for `getVideoTracks` or `getAudioTracks`

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,6 @@
 ## 0.1.14
 ### Fixed
-- Update WebM container for VP8 video to include Opus audio so that MediaRecorder works for Firefox >= 71
+- Added WebM container for VP8 video to include Opus audio so that MediaRecorder works for Firefox >= 71
 
 ## 0.1.13
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webcam-onfido",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "React webcam component",
   "main": "dist/react-webcam.js",
   "scripts": {

--- a/src/video.js
+++ b/src/video.js
@@ -11,7 +11,7 @@ const handleStop = (event) => {
 };
 
 const videoOptions = () => {
-  let mimeTypes = ['video/webm;codecs=vp9', 'video/webm;codecs=vp8', 'video/webm'];
+  let mimeTypes = ['video/webm;codecs=vp9', 'video/webm;codecs=vp8,opus', 'video/webm'];
   let mimeType = '';
   for (let type in mimeTypes) {
     if (MediaRecorder.isTypeSupported(mimeTypes[type])) {

--- a/src/video.js
+++ b/src/video.js
@@ -11,7 +11,12 @@ const handleStop = (event) => {
 };
 
 const videoOptions = () => {
-  let mimeTypes = ['video/webm;codecs=vp9', 'video/webm;codecs=vp8,opus', 'video/webm'];
+  let mimeTypes = [
+    'video/webm;codecs=vp9',
+    'video/webm;codecs=vp8,opus',
+    'video/webm;codecs=vp8',
+    'video/webm'
+  ];
   let mimeType = '';
   for (let type in mimeTypes) {
     if (MediaRecorder.isTypeSupported(mimeTypes[type])) {


### PR DESCRIPTION
# Problem
The video variant of the face step doesn't work on Firefox >= 71. It was working in Firefox 70.
More details: https://github.com/onfido/onfido-sdk-ui/issues/891

# Solution
Include WebM container for VP8 video and Opus audio codec