### PR TITLE
ET-9 fixing video stream mirroring problem for some rear facing cameras

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+## 0.1.16
+### Fixed
+- Resolved the video stream mirroring problem for the rear camera on certain browsers
+
 ## 0.1.15
 ### Added
 - Added alternative constraint workaround to evoke the rear camera of Surface Pro in Chrome since it will not respect facingMode constraint

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webcam-onfido",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "React webcam component",
   "main": "dist/react-webcam.js",
   "scripts": {

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -207,12 +207,18 @@ export default class Webcam extends Component<CameraType, State> {
   handleUserMedia(stream: MediaStream) {
     const videoSettings = stream ? stream.getVideoTracks()[0].getSettings() : {}; // check for stream, assign empty object if none
     debugConsole('video track settings', videoSettings);
+    const facingMode = this.props.facingMode;
+    /* If the facingMode for the webcam was passed in as "environment" or {exact: "environment"} we don't want to mirror the video stream,
+    since we will be seeing  the stream of the rear camera*/
+    const isVideoStreamForRearCamera = (facingMode === "environment" || (facingMode && facingMode.exact && facingMode.exact === "environment" ));
+
     this.setState({
       hasUserMedia: true,
-      mirrored: videoSettings.facingMode === 'user'
+      mirrored: !isVideoStreamForRearCamera
+                && (videoSettings.facingMode === 'user'
                 /* #HACK desktop cameras seem to have `facingMode` undefined,
                 therefore we are assuming all desktop cameras are user facing*/
-                || !videoSettings.facingMode
+                || !videoSettings.facingMode)
     });
 
     this.props.onUserMedia();


### PR DESCRIPTION
# Problem
On some browser/device combinations, the video stream is mirrored on the document capture step using the rear camera

# Solution
If the facingMode passed into the props of the webcam were "environment" or {exact: "environment"} We know we're trying to use the rear camera and don't want it mirrored, so set mirrored to false if this is the case

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
