### PR TITLE
ET-9 Adding label match to identify 'world' facing camera on hp elite x2

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+## 0.1.17
+### Fixed
+- Added label option to the Chrome workaround to support HP Elite X2
+
 ## 0.1.16
 ### Fixed
 - Resolved the video stream mirroring problem for the rear camera on certain browsers

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -20,7 +20,7 @@ const environmentCamConstraint = (constraints) => {
     facingMode = facingMode && ((typeof facingMode === 'object') ? facingMode : {ideal: facingMode});
     let matches = [];
     if (facingMode.exact === 'environment' || facingMode.ideal === 'environment') {
-      matches = ['back', 'rear'];
+      matches = ['back', 'rear', 'world'];
     }
     if (matches) {
       return enumerateDevices().then(devices => {


### PR DESCRIPTION
# Problem
The client is using an HP Elite X2, which has the same problem that the Surface did on Chrome, therefore, it needs the same workaround. However, the workaround depends on catching a keyword in the device label. 'Back' and 'Rear' cover most cases, but the HP Elite X2 labels that camera as 'World' facing.

# Solution
Add 'world' to the list of keywords to look for in the workaround

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?