### PR TITLE
Add warning about Safari 13.1 bug

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+## 0.1.19
+### Added
+- Added warning about Safari 13.1 bug that affects devices result from multiple calls to navigator.mediaDevices.enumerateDevices()
+
 ## 0.1.18
 ### Fixed
 - Fixed camera stream not getting on some Android devices, e.g. Motorola G5, Samsung Galaxy A6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webcam-onfido",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "React webcam component",
   "main": "dist/react-webcam.js",
   "scripts": {

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -23,6 +23,8 @@ const environmentCamConstraint = (constraints) => {
       matches = ['back', 'rear', 'world'];
     }
     if (matches) {
+      // WARN: there is a bug in Safari 13.1 that affects subsequent calls to navigator.mediaDevices.enumerateDevices()
+      // https://bugs.webkit.org/show_bug.cgi?id=209580
       return enumerateDevices().then(devices => {
         devices = devices.filter(d => d.kind === 'videoinput');
         let device = devices.find(d => matches.some(match =>


### PR DESCRIPTION
Add a warning about [Safari 13.1 bug](https://bugs.webkit.org/show_bug.cgi?id=209580) in react-webcam to prevent developers from calling enumerateDevices() in a way that would break Safari